### PR TITLE
regodoc example

### DIFF
--- a/policies/kubernetes/policy/is_privileged.rego
+++ b/policies/kubernetes/policy/is_privileged.rego
@@ -7,11 +7,9 @@ __rego__metadoc__ := {
   "title": "Privileged",
   "description": "Privileged containers share namespaces with the host system and do not offer any security. They should be used exclusively for system containers that require high privileges.",
   "custom": {
-    "notes": [
-      "Recommendation: Change 'containers[].securityContext.privileged' to 'false'",
-      "Severity: High"
-    ]
-  ],
+      "Recommendation": "Change 'containers[].securityContext.privileged' to 'false'",
+      "Severity": "High"
+  },
   "entrypoint": "main.deny",
   "input": "Kubernetes Pod spec OR a Kubernetes admission review object with for a Pod spec",
   "output": "Set of messages pertaining to affected items",

--- a/policies/kubernetes/policy/is_privileged.rego
+++ b/policies/kubernetes/policy/is_privileged.rego
@@ -1,13 +1,23 @@
-# @title: Privileged
-# @description: Privileged containers share namespaces with the host system and do not offer any security. They should be used exclusively for system containers that require high privileges.
-# @recommended_actions: Change 'containers[].securityContext.privileged' to 'false'.
-# @severity: High
-# @id: KSV017
-# @links: 
-
 package main
 
 import data.lib.kubernetes
+
+__rego__metadoc__ := {
+  "id": "KSV017",
+  "title": "Privileged",
+  "description": "Privileged containers share namespaces with the host system and do not offer any security. They should be used exclusively for system containers that require high privileges.",
+  "notes": [
+    "Recommendation: Change 'containers[].securityContext.privileged' to 'false'",
+    "Severity: High"
+  ],
+  "entrypoint": "main.deny",
+  "input": "Kubernetes Pod spec OR a Kubernetes admission review object with for a Pod spec",
+  "output": "Set of messages pertaining to affected items",
+  "examples": [
+    "test_Privileged_is_true",
+    "test_Privileged_is_false"
+  ]
+}
 
 default failPrivileged = false
 

--- a/policies/kubernetes/policy/is_privileged.rego
+++ b/policies/kubernetes/policy/is_privileged.rego
@@ -14,8 +14,8 @@ __rego__metadoc__ := {
   "input": "Kubernetes Pod spec OR a Kubernetes admission review object with for a Pod spec",
   "output": "Set of messages pertaining to affected items",
   "examples": [
-    "test_Privileged_is_true",
-    "test_Privileged_is_false"
+    "main.test_Privileged_is_true",
+    "main.test_Privileged_is_false"
   ]
 }
 

--- a/policies/kubernetes/policy/is_privileged.rego
+++ b/policies/kubernetes/policy/is_privileged.rego
@@ -6,9 +6,11 @@ __rego__metadoc__ := {
   "id": "KSV017",
   "title": "Privileged",
   "description": "Privileged containers share namespaces with the host system and do not offer any security. They should be used exclusively for system containers that require high privileges.",
-  "notes": [
-    "Recommendation: Change 'containers[].securityContext.privileged' to 'false'",
-    "Severity: High"
+  "custom": {
+    "notes": [
+      "Recommendation: Change 'containers[].securityContext.privileged' to 'false'",
+      "Severity: High"
+    ]
   ],
   "entrypoint": "main.deny",
   "input": "Kubernetes Pod spec OR a Kubernetes admission review object with for a Pod spec",


### PR DESCRIPTION
Do not merge. This is an example for how we can migrate our rego policies to the regodoc proposal