### PR TITLE
Improve Kubernetes readme

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -29,7 +29,7 @@ conftest test test.yaml --policy myPolicy/
 ```
 
 # Standards and best practices
-The controls of both Pod Security Policy (PSP) and Pod Security Standards (PSS) and additional best practices are covered in this github repository
+This GitHub repository has controls that cover both [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) (PSP) and the Kubernetes [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) (PSS), plus additional best practices.
 
 ## PSS and PSP
 Pod Security Standard (PSS) is the official standard for security best practices for pods and it overlaps with the checks that PSP perform

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -32,13 +32,11 @@ conftest test test.yaml --policy myPolicy/
 This GitHub repository has controls that cover both [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) (PSP) and the Kubernetes [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) (PSS), plus additional best practices.
 
 ## PSS and PSP
-Pod Security Standard (PSS) is the official standard for security best practices for pods and it overlaps with the checks that PSP perform
-- PSS: https://kubernetes.io/docs/concepts/security/pod-security-standards/
-- PSP: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+The Kubernetes Pod Security Standards (PSS) are the official standard for security best practices for pods. These standards overlaps with the checks that PodSecurityPolicies can enforce.
 
-PSS has 14 controls that are grouped into two policies: Baseline and Restricted. We named the controls in this repository under the PSS controls because they are more up-to-date and have better coverage than PSP. The below table maps PSS controls to PSP controls:
+PSS has 14 controls that are grouped into three standards: Baseline, Restricted and Privileged. Appshield uses Baseline and Restricted; the Privileged standard specifically allows privileged execution. We named the controls in this repository under the PSS controls because they are more up-to-date and have better coverage than PSP. The below table maps PSS controls to PSP controls:
 
-### PSS - baseline
+### PSS - Baseline
 
 PSS control | PSP control(s)
 ------------ | -------------
@@ -54,7 +52,7 @@ PSS control | PSP control(s)
 
 The REGO rules are available [here](https://github.com/aquasecurity/appshield/tree/master/kubernetes/policies/pss)
 
-### PSS - restricted
+### PSS - Restricted
 
 PSS control | PSP control
 ------------ | -------------


### PR DESCRIPTION
Improve how the Kubernetes [README](https://github.com/aquasecurity/appshield/tree/master/kubernetes#readme) explains Pod security standards and PodSecurityPolicy.

[_preview_](https://github.com/aquasecurity/appshield/blob/aed184b7ef2a2c06c309623fe6aee837ceeaba7c/kubernetes/README.md)