### PR TITLE
Correctly parse docker images that contain digests

### DIFF
--- a/kubernetes/policies/general/uses_image_tag_latest.rego
+++ b/kubernetes/policies/general/uses_image_tag_latest.rego
@@ -24,8 +24,8 @@ __rego_input__ := {
 # have tagged images.
 getTaggedContainers[container] {
 	allContainers := kubernetes.containers[_]
-	[x, y] := split(allContainers.image, ":")
-	y != "latest"
+	tag := split(split(allContainers.image, "@")[0], ":")[1]
+	tag != "latest"
 	container := allContainers.name
 }
 

--- a/kubernetes/policies/general/uses_image_tag_latest_test.rego
+++ b/kubernetes/policies/general/uses_image_tag_latest_test.rego
@@ -58,3 +58,62 @@ test_tagged_image_allowed {
 
 	count(r) == 0
 }
+
+test_tagged_image_with_digest_allowed {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "hello-tag"},
+		"spec": {"containers": [{
+			"command": [
+				"sh",
+				"-c",
+				"echo 'Hello' && sleep 1h",
+			],
+			"image": "busybox:1.33.1@sha256:askj78jhkf278hdjkf78623gbkljmkvmk8kjn98237487hkjaf897bkjsehf783f",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_tagged_image_with_digest_denied {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "hello-tag"},
+		"spec": {"containers": [{
+			"command": [
+				"sh",
+				"-c",
+				"echo 'Hello' && sleep 1h",
+			],
+			"image": "busybox:latest@sha256:askj78jhkf278hdjkf78623gbkljmkvmk8kjn98237487hkjaf897bkjsehf783f",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Container 'hello' of Pod 'hello-tag' should specify an image tag"
+}
+
+test_image_with_no_tag_with_digest_denied {
+	r := deny with input as {
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "hello-tag"},
+		"spec": {"containers": [{
+			"command": [
+				"sh",
+				"-c",
+				"echo 'Hello' && sleep 1h",
+			],
+			"image": "busybox@sha256:askj78jhkf278hdjkf78623gbkljmkvmk8kjn98237487hkjaf897bkjsehf783f",
+			"name": "hello",
+		}]},
+	}
+
+	count(r) == 1
+	r[_].msg == "Container 'hello' of Pod 'hello-tag' should specify an image tag"
+}


### PR DESCRIPTION
Fixes #132

If a container's image contains a digest, that is failing the "latest" tag check.  Update the logic that parses the image to remove the digest (if present) and then split on `:` to get the tag.