### PR TITLE
feat/protecting pod service account tokens

### DIFF
--- a/kubernetes/policies/advanced/protecting_pod_service_account_tokens.rego
+++ b/kubernetes/policies/advanced/protecting_pod_service_account_tokens.rego
@@ -28,17 +28,14 @@ deny[res] {
 }
 
 mountServiceAccountToken(spec) {
+	has_key(spec, "automountServiceAccountToken")
 	spec.automountServiceAccountToken == true
 }
 
 # if there is no automountServiceAccountToken spec, check on volumeMount in containers. Service Account token is mounted on /var/run/secrets/kubernetes.io/serviceaccount
 mountServiceAccountToken(spec) {
 	not has_key(spec, "automountServiceAccountToken")
-	"/var/run/secrets/kubernetes.io/serviceaccount" == spec.input_containers.volumeMounts[_].mountPath
-}
-
-input_containers[c] {
-	c = kubernetes.containers[_]
+	"/var/run/secrets/kubernetes.io/serviceaccount" == kubernetes.containers[_].volumeMounts[_].mountPath
 }
 
 has_key(x, k) {

--- a/kubernetes/policies/advanced/protecting_pod_service_account_tokens.rego
+++ b/kubernetes/policies/advanced/protecting_pod_service_account_tokens.rego
@@ -1,0 +1,46 @@
+package appshield.kubernetes.KSV036
+
+import data.lib.kubernetes
+import data.lib.utils
+
+__rego_metadata__ := {
+	"id": "KSV036",
+	"title": "Protecting Pod service account tokens",
+	"version": "v1.0.0",
+	"severity": "MEDIUM",
+	"type": "Kubernetes Security Check",
+	"description": "ensure that Pod specifications disable the secret token being mounted by setting automountServiceAccountToken: false",
+	"recommended_actions": "Remove 'container.apparmor.security.beta.kubernetes.io' annotation or set it to 'runtime/default'.",
+	"url": "https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#serviceaccount-admission-controller",
+}
+
+deny[res] {
+	mountServiceAccountToken(input.spec)
+	msg := kubernetes.format(sprintf("Container of %s '%s' should set 'spec.automountServiceAccountToken' to false", [kubernetes.kind, kubernetes.name]))
+
+	res := {
+		"msg": msg,
+		"id": __rego_metadata__.id,
+		"title": __rego_metadata__.title,
+		"severity": __rego_metadata__.severity,
+		"type": __rego_metadata__.type,
+	}
+}
+
+mountServiceAccountToken(spec) {
+	spec.automountServiceAccountToken == true
+}
+
+# if there is no automountServiceAccountToken spec, check on volumeMount in containers. Service Account token is mounted on /var/run/secrets/kubernetes.io/serviceaccount
+mountServiceAccountToken(spec) {
+	not has_key(spec, "automountServiceAccountToken")
+	"/var/run/secrets/kubernetes.io/serviceaccount" == spec.input_containers.volumeMounts[_].mountPath
+}
+
+input_containers[c] {
+	c = kubernetes.containers[_]
+}
+
+has_key(x, k) {
+	_ = x[k]
+}

--- a/kubernetes/policies/advanced/protecting_pod_service_account_tokens_test.rego
+++ b/kubernetes/policies/advanced/protecting_pod_service_account_tokens_test.rego
@@ -1,0 +1,76 @@
+package appshield.kubernetes.KSV036
+
+test_protect_service_account_token_denied_with_automountServiceAccountToken {
+	r := deny with input as {
+		"kind": "pod",
+		"name": "justPOod",
+		"metadata": {"name": "nginx"},
+		"spec": {
+			"automountServiceAccountToken": true,
+			"containers": [{
+				"name": "nginx",
+				"image": "nginx",
+				"volumeMounts": [{
+					"name": "serviceaccount-vm",
+					"mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+				}],
+			}],
+		},
+	}
+
+	r[_].msg == "Container of pod 'nginx' should set 'spec.automountServiceAccountToken' to false"
+}
+
+test_protect_service_account_token_denied_without_automountServiceAccountToken {
+	r := deny with input as {
+		"kind": "pod",
+		"name": "justPOod",
+		"metadata": {"name": "nginx"},
+		"spec": {"containers": [{
+			"name": "nginx",
+			"image": "nginx",
+			"volumeMounts": [{
+				"name": "serviceaccount-vm",
+				"mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+			}],
+		}]},
+	}
+
+	r[_].msg == "Container of pod 'nginx' should set 'spec.automountServiceAccountToken' to false"
+}
+
+test_protect_service_account_token_denied_without_mountPath {
+	r := deny with input as {
+		"kind": "pod",
+		"name": "justPOod",
+		"metadata": {"name": "nginx"},
+		"spec": {"containers": [{
+			"name": "nginx",
+			"image": "nginx",
+			"volumeMounts": [{"name": "serviceaccount-vm"}],
+		}]},
+	}
+
+	count(r) == 0
+}
+
+test_protect_service_account_token_allow {
+	r := deny with input as {
+		"kind": "pod",
+		"name": "jusPOod",
+		"metadata": {"name": "nginx"},
+		"spec": {
+			"automountServiceAccountToken": false,
+			"containers": [{
+				"name": "nginx",
+				"image": "nginx",
+				"volumeMounts": [{
+					"name": "serviceaccount-vm",
+					"mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+				}],
+			}],
+		},
+	}
+
+	count(r) == 0
+}


### PR DESCRIPTION
Supporting  `automountServiceAccountToken: false`  pod parameter check to disable the secret token being mounted