### PR TITLE
feat: selectors usage in network policy

### DIFF
--- a/avd_docs/kubernetes/advanced/AVD-KSV-0038/docs.md
+++ b/avd_docs/kubernetes/advanced/AVD-KSV-0038/docs.md
@@ -1,0 +1,13 @@
+
+### Selector usage in network policies
+ensure that network policies selectors are applied to pods or namespaces to restricted ingress and egress traffic within the pod network
+
+### Impact
+<!-- Add Impact here -->
+
+<!-- DO NOT CHANGE -->
+{{ remediationActions }}
+
+### Links
+- https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy/
+

--- a/kubernetes/policies/advanced/selector_usage_in_network_policies.rego
+++ b/kubernetes/policies/advanced/selector_usage_in_network_policies.rego
@@ -1,0 +1,73 @@
+package appshield.kubernetes.KSV038
+
+import data.lib.kubernetes
+import data.lib.utils
+
+__rego_metadata__ := {
+	"id": "KSV038",
+	"avd_id": "AVD-KSV-0038",
+	"title": "Selector usage in network policies",
+	"short_code": "selector-usage-in-network-policies",
+	"version": "v1.0.0",
+	"severity": "MEDIUM",
+	"type": "Kubernetes Security Check",
+	"description": "ensure that network policies selectors are applied to pods or namespaces to restricted ingress and egress traffic within the pod network",
+	"recommended_actions": "create network policies and ensure that pods are selected using the podSelector and/or the namespaceSelector options",
+	"url": "https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy/",
+}
+
+deny[res] {
+	not hasSelector(input.spec)
+	msg := "Network policy should uses podSelector and/or the namespaceSelector to restrict ingress and egress traffic within the Pod network"
+	res := {
+		"msg": msg,
+		"id": __rego_metadata__.id,
+		"title": __rego_metadata__.title,
+		"severity": __rego_metadata__.severity,
+		"type": __rego_metadata__.type,
+	}
+}
+
+hasSelector(spec) {
+	lower(kubernetes.kind) == "networkpolicy"
+	kubernetes.has_field(spec, "podSelector")
+	kubernetes.has_field(spec.podSelector, "matchLabels")
+}
+
+hasSelector(spec) {
+	lower(kubernetes.kind) == "networkpolicy"
+	kubernetes.has_field(spec, "namespaceSelector")
+}
+
+hasSelector(spec) {
+	lower(kubernetes.kind) == "networkpolicy"
+	kubernetes.has_field(spec, "podSelector")
+}
+
+hasSelector(spec) {
+	lower(kubernetes.kind) == "networkpolicy"
+	kubernetes.has_field(spec, "ingress")
+	kubernetes.has_field(spec.ingress[_], "from")
+	kubernetes.has_field(spec.ingress[_].from[_], "namespaceSelector")
+}
+
+hasSelector(spec) {
+	lower(kubernetes.kind) == "networkpolicy"
+	kubernetes.has_field(spec, "ingress")
+	kubernetes.has_field(spec.ingress[_], "from")
+	kubernetes.has_field(spec.ingress[_].from[_], "podSelector")
+}
+
+hasSelector(spec) {
+	lower(kubernetes.kind) == "networkpolicy"
+	kubernetes.has_field(spec, "egress")
+	kubernetes.has_field(spec.egress[_], "to")
+	kubernetes.has_field(spec.egress[_].to[_], "podSelector")
+}
+
+hasSelector(spec) {
+	lower(kubernetes.kind) == "networkpolicy"
+	kubernetes.has_field(spec, "egress")
+	kubernetes.has_field(spec.egress[_], "to")
+	kubernetes.has_field(spec.egress[_].to[_], "namespaceSelector")
+}

--- a/kubernetes/policies/advanced/selector_usage_in_network_policies_test.rego
+++ b/kubernetes/policies/advanced/selector_usage_in_network_policies_test.rego
@@ -1,0 +1,84 @@
+package appshield.kubernetes.KSV038
+
+test_networkpolicy_with_spec_pod_selector {
+	r := deny with input as {
+		"apiVersion": "networking.k8s.io/v1",
+		"kind": "NetworkPolicy",
+		"metadata": {"name": "access-nginx"},
+		"spec": {
+			"podSelector": {"matchLabels": {"app": "nginx"}},
+			"ingress": [{"from": [{"podSelector": {"matchLabels": {"access": "true"}}}]}],
+		},
+	}
+
+	count(r) == 0
+}
+
+test_networkpolicy_without_selector {
+	r := deny with input as {
+		"apiVersion": "networking.k8s.io/v1",
+		"kind": "NetworkPolicy",
+		"metadata": {"name": "access-nginx"},
+		"spec": {"ingress": [{"from": [{}]}]},
+	}
+
+	r[_].msg == "Network policy should uses podSelector and/or the namespaceSelector to restrict ingress and egress traffic within the Pod network"
+}
+
+test_networkpolicy_with_spec_namespace_selector {
+	r := deny with input as {
+		"apiVersion": "networking.k8s.io/v1",
+		"kind": "NetworkPolicy",
+		"metadata": {"name": "access-nginx"},
+		"spec": {
+			"namespaceSelector": {"matchLabels": {"app": "nginx"}},
+			"ingress": [{"from": [{"podSelector": {"matchLabels": {"access": "true"}}}]}],
+		},
+	}
+
+	count(r) == 0
+}
+
+test_networkpolicy_with_ingress_pod_selector {
+	r := deny with input as {
+		"apiVersion": "networking.k8s.io/v1",
+		"kind": "NetworkPolicy",
+		"metadata": {"name": "access-nginx"},
+		"spec": {"ingress": [{"from": [{"podSelector": {"matchLabels": {"access": "true"}}}]}]},
+	}
+
+	count(r) == 0
+}
+
+test_networkpolicy_with_ingress_namespace_selector {
+	r := deny with input as {
+		"apiVersion": "networking.k8s.io/v1",
+		"kind": "NetworkPolicy",
+		"metadata": {"name": "access-nginx"},
+		"spec": {"ingress": [{"from": [{"namespaceSelector": {"matchLabels": {"access": "true"}}}]}]},
+	}
+
+	count(r) == 0
+}
+
+test_networkpolicy_with_egress_namespace_selector {
+	r := deny with input as {
+		"apiVersion": "networking.k8s.io/v1",
+		"kind": "NetworkPolicy",
+		"metadata": {"name": "access-nginx"},
+		"spec": {"egress": [{"to": [{"namespaceSelector": {"matchLabels": {"access": "true"}}}]}]},
+	}
+
+	count(r) == 0
+}
+
+test_networkpolicy_with_egress_pod_selector {
+	r := deny with input as {
+		"apiVersion": "networking.k8s.io/v1",
+		"kind": "NetworkPolicy",
+		"metadata": {"name": "access-nginx"},
+		"spec": {"egress": [{"to": [{"podSelector": {"matchLabels": {"access": "true"}}}]}]},
+	}
+
+	count(r) == 0
+}


### PR DESCRIPTION
ensure that network policies selectors are applied to pods or namespaces to restricted ingress and egress traffic within the pod network.
Signed-off-by: chen-keinan <hen.keinan@gmail.com>