### PR TITLE
Fix typo in recommended action for DS006

### DIFF
--- a/docker/policies/copy_from_references_current_from_alias.rego
+++ b/docker/policies/copy_from_references_current_from_alias.rego
@@ -11,7 +11,7 @@ __rego_metadata__ := {
 	"severity": "CRITICAL",
 	"type": "Dockerfile Security Check",
 	"description": "COPY '--from' should not mention the current FROM alias, since it is impossible to copy from itself.",
-	"recommended_actions": "Change the '--form' so that it will not refer to itself",
+	"recommended_actions": "Change the '--from' so that it will not refer to itself",
 	"url": "https://docs.docker.com/develop/develop-images/multistage-build/",
 }
 


### PR DESCRIPTION
The option should be `--from` instead of `--form`.